### PR TITLE
style: add max-with to videos inside modules descriptions

### DIFF
--- a/src/app/modules/marketplace/components/module-detail/module-detail.component.scss
+++ b/src/app/modules/marketplace/components/module-detail/module-detail.component.scss
@@ -29,6 +29,10 @@
     max-width: 100%;
 }
 
+::ng-deep .module-description video {
+    max-width: 600px;
+}
+
 .tags span {
     display: inline-block;
     height: 24px;


### PR DESCRIPTION
Videos inside the modules descriptions were too big and making the right column (categories, buttons....) display badly. Set max-with to 600px.