### PR TITLE
Fix: Logout user when token is expired and can't be refreshed. Show Snackbar with custom message for this.

### DIFF
--- a/src/app/core/services/auth/auth.service.ts
+++ b/src/app/core/services/auth/auth.service.ts
@@ -122,6 +122,8 @@ export class AuthService {
                                     // 3. ASK FOR LOGIN:
                                     this.login(state);
                                     return Promise.resolve();
+                                } else {
+                                    this.logout();
                                 }
                                 return Promise.reject(result);
                             });

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -203,7 +203,8 @@
         "DOCKERHUB": "Dockerhub"
     },
     "ERRORS": {
-        "SERVICE-ERROR": "Error calling the API, please retry later",
+        "API-ERROR": "Error calling the API, please retry later",
+        "TOKEN-EXPIRED": "Token expired, logging out",
         "NOT-AUTHORIZED-ERROR": "*You need to be enrolled in the '{{vo}}' VO to be able to deploy",
         "NOT-FOUND": "Oops, the page you requested could not be found!"
     }


### PR DESCRIPTION
Whenever a user entered the dashboard after being away for a long time, the token refresh function was failing and showing a error message related to the API which was misleading.

Now when this situation happens, the user will be logged out with a message related to this and not the API.